### PR TITLE
set main filed in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "share",
         "jquery-plugin"
     ],
-    "version": "0.2.7",
+    "version": "0.2.8",
     "dependencies": {
         "jquery": ">=1.6"
     },
@@ -16,6 +16,7 @@
         "email" : "bps@dzen.ws",
         "url" : "https://github.com/AyumuKasuga/"
     },
+    "main": "SocialShare.js",
     "licenses": [
         {
             "type": "MIT",


### PR DESCRIPTION
ref: https://docs.npmjs.com/files/package.json#main

Then, I can use `require('social-share-jquery')` in nodejs or es6 relative projects, it will automatically import the file which defined in main filed.